### PR TITLE
Update docker file to use `redis/redis-stack`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,22 @@ There is a `docker-compose-redis-only.yml` file in the root of this repository
 that you can use to start a Redis server locally. Just run:
 
 ```bash
-docker compose -f docker-compose-redis-only.yml u
+docker compose -f docker-compose-redis-only.yml up -d
 ```
 
-This will start a Redis server on `localhost:6379`, without any password.
+This will spin up a Redis server on `localhost:6379`, without any password,
+running in the background. You can stop it with:
+
+```bash
+docker compose -f docker-compose-redis-only.yml down
+```
+
+The image is based on
+[redis/redis-stack](https://redis.io/docs/install/install-stack/docker/) so also
+includes [RedisInsight](https://redis.io/docs/connect/insight/) running on port
+`8001` that you can use to inspect the Redis server.
+
+**Note that this is a development server and should not be used in production.**
 
 ### Initialize Redis in your FastAPI application
 

--- a/docker-compose-redis-only.yml
+++ b/docker-compose-redis-only.yml
@@ -1,11 +1,10 @@
-version: "3.8"
 services:
   cache:
-    image: redis:7.2-alpine
+    image: redis/redis-stack:latest
     restart: always
     ports:
       - "6379:6379"
-    command: redis-server --save 20 1
+      - "8001:8001"
     volumes:
       - cache:/data
 volumes:


### PR DESCRIPTION
This uses the latest `redis-stack` image which also includes `RedisInsight` running on port 8001. 

> NOTE:
> The docker-based Redis server is really only for development purposes.